### PR TITLE
Add default concerns also to ActionController::API

### DIFF
--- a/lib/betterdoc/containerservice/railtie.rb
+++ b/lib/betterdoc/containerservice/railtie.rb
@@ -41,6 +41,12 @@ module Betterdoc
             include Betterdoc::Containerservice::Controllers::Concerns::AuthenticationConcern
             include Betterdoc::Containerservice::Controllers::Concerns::StackerConcern
           end
+          class ActionController::API
+            include Betterdoc::Containerservice::Controllers::Concerns::HttpHelpersConcern
+            include Betterdoc::Containerservice::Controllers::Concerns::HttpResponseMetadataConcern
+            include Betterdoc::Containerservice::Controllers::Concerns::AuthenticationConcern
+            include Betterdoc::Containerservice::Controllers::Concerns::StackerConcern
+          end
         end
 
         # Make sure that all our *helpers* are made available to the template evaluation engine


### PR DESCRIPTION
Make sure the default concerns are also applied to API only projects when using `ActionController::API` as base class