### PR TITLE
Gem is now Rails Engine with default layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ The following code snippes demonstrate some shortcuts that can be used to render
 ```ruby
 def some_controller_method
   return render_containerservice_error(404, "Object not found") if object_not_found
-  
+
   # ...
-  
+
 end
 ```
 
@@ -77,8 +77,12 @@ end
 
 Renders the template specified under `:template_name`.
 
-Only if either the HTTP parameter `full_html` is set to `true` for the current request or an environment variable named `CONTAINERSERVICE_FULL_HTML` is set to `true` will the layout be applied to the template. 
+Only if either the HTTP parameter `full_html` is set to `true` for the current request or an environment variable named `CONTAINERSERVICE_FULL_HTML` is set to `true` will the layout be applied to the template.
 Otherwise (the default case) only the plain template will be rendered and returned to the client.
+
+### Layout
+
+Gem is written as Rails Engine and contains default layout (for development) at [app/views/layouts/application.html.erb](app/views/layouts/application.html.erb). This means that container should NOT have its own application layout. If you have one run `rm app/views/layouts/application.html.erb` to remove it. If you want to override default layout just add `app/views/layouts/application.html.erb` to your app :)
 
 ### Helpers
 
@@ -88,7 +92,7 @@ When the content of the container service is rendered inside a Stack (composed b
 
 Let's take an example:
 
-A Stack is available at `http://example.com/stack/abc`. 
+A Stack is available at `http://example.com/stack/abc`.
 This stack aggregates the content from services `foo` and `bar`.
 With the content of `foo` we want to link to another stack named `def`:
 
@@ -133,9 +137,9 @@ The output can also be combined with the standard Rails `link_to` tag:
 ```
 
 #### Stacker request flag
- 
-When Stacker sends requests to a container service, a header, amongst others, is sent `HTTP_X_STACKER_ROOT_URL`. 
-A helper method `stacker_request?` exists in this repository that allows containers to check the flag if the actual request is sent from Stacker. 
+
+When Stacker sends requests to a container service, a header, amongst others, is sent `HTTP_X_STACKER_ROOT_URL`.
+A helper method `stacker_request?` exists in this repository that allows containers to check the flag if the actual request is sent from Stacker.
 
 
 ### Other functionalities

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= Rails.application.class.to_s.split("::").first %></title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <link rel="stylesheet" href="https://betterdoc-materialize.herokuapp.com/materialize/dist/css/betterdoc-materialize.min.css">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700,800" />
+    <link rel="stylesheet" href="https://betterdoc-materialize.herokuapp.com/mdc/dist/css/betterdoc-mdc.css">
+  </head>
+
+  <body>
+    <%= yield %>
+
+    <script src="https://betterdoc-materialize.herokuapp.com/materialize/dist/js/betterdoc-materialize.min.js"></script>
+    <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+
+     <script>
+        if (window.M) {
+          window.M.AutoInit();
+        }
+        if (window.mdc) {
+          window.mdc.autoInit();
+        }
+    </script>
+  </body>
+</html>

--- a/lib/betterdoc/containerservice/controllers/concerns/stacker_concern.rb
+++ b/lib/betterdoc/containerservice/controllers/concerns/stacker_concern.rb
@@ -6,7 +6,7 @@ module Betterdoc
           extend ActiveSupport::Concern
 
           included do
-            helper_method :stacker_request?
+            helper_method :stacker_request? if respond_to?(:helper_method)
           end
 
           def stacker_request?

--- a/lib/betterdoc/containerservice/engine.rb
+++ b/lib/betterdoc/containerservice/engine.rb
@@ -1,0 +1,6 @@
+module Betterdoc
+  module Containerservice
+    class Engine < ::Rails::Engine
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/betterdoc-org/parc/issues/107

Once we merge this we should for all container services:

* Update the gem `bundle update betterdoc-containerservice`
* Remove old layout `rm app/views/layouts/application.html.erb`