### PR TITLE
Add application hook to load and initialize the Instrumental API agent

### DIFF
--- a/betterdoc-containerservice.gemspec
+++ b/betterdoc-containerservice.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+  spec.add_dependency 'instrumental_agent', '~> 2.1.0'
   spec.add_dependency 'jwt', '~> 2.1.0'
   spec.add_dependency 'logging', '~> 2.2.2'
   spec.add_dependency 'logging-rails', '~> 0.6.0'

--- a/lib/betterdoc/containerservice/railtie.rb
+++ b/lib/betterdoc/containerservice/railtie.rb
@@ -56,6 +56,14 @@ module Betterdoc
           end
         end
 
+        # Make sure that external APIs can be initialized here before application starts
+        ActiveSupport.on_load(:before_initialize) do
+          if ENV['MONITOR_INSTRUMENTAL_API_KEY'].present?
+            require 'instrumental_agent'
+            @instrumental_agent ||= Instrumental::Agent.new(ENV['MONITOR_INSTRUMENTAL_API_KEY'])
+          end
+        end
+
       end
 
     end


### PR DESCRIPTION
This is part of the changes for the Friday project in which I introduced a monitoring tool for our web services. This monitoring tool is called [Instrumental](https://github.com/Instrumental/instrumental_agent-ruby). 

This change will make this agent available for all services that have this gem included. In this way, the services would not have to be modified and changes can be made centrally only here for all services. This change also exposes the variable `@instrumental_agent` which can be used by the depending services as well. 

Dependent services have to add the env variable `MONITOR_INSTRUMENTAL_API_KEY` to be able to record metrics. See [Instrumental metrics documentation](https://instrumentalapp.com/docs/metrics) for more information.