### PR TITLE
feature/link to stack

### DIFF
--- a/lib/betterdoc/containerservice/helpers/link_helper.rb
+++ b/lib/betterdoc/containerservice/helpers/link_helper.rb
@@ -8,8 +8,15 @@ module Betterdoc
         extend ActiveSupport::Concern
         include ActionView::Helpers::UrlHelper
 
-        def link_to_stack(content, stack, url_options = {}, html_options = {})
-          stack_url = stacker_link_url("stacks/#{stack}", url_options)
+        # link_to_stack("some-stack", {}, data: { foo_bar: "fiz-baz" }) do ...
+        # link_to_stack(content -> stack, stack -> url_options, url_options -> html_options) do content
+
+        # link_to_stack("Go to some stack", "some-stack", {}, data: { foo_bar: "fiz-baz" })
+        # link_to_stack(content, stack, url_options, html_options)
+
+        def link_to_stack(content, stack, url_options = {}, html_options = {}, &block)
+          html_options, url_options, stack, content = url_options, stack, content, block if block_given?
+          stack_url = ["/stack/#{stack}", url_options.to_query.presence].compact.join("?") 
           html_options[:data] ||= {}
           html_options[:data][:stacker_no_hijack] = "true"
           link_to(content, stack_url, html_options)

--- a/lib/betterdoc/containerservice/helpers/link_helper.rb
+++ b/lib/betterdoc/containerservice/helpers/link_helper.rb
@@ -1,10 +1,19 @@
 require 'cgi'
+require 'action_view/helpers'
 
 module Betterdoc
   module Containerservice
     module Helpers
       module LinkHelper
         extend ActiveSupport::Concern
+        include ActionView::Helpers::UrlHelper
+
+        def link_to_stack(content, stack, url_options = {}, html_options = {})
+          stack_url = stacker_link_url("stacks/#{stack}", url_options)
+          html_options[:data] ||= {}
+          html_options[:data][:stacker_no_hijack] = "true"
+          link_to(content, stack_url, html_options)
+        end
 
         def stacker_link_url(target_path, parameters = {})
           result_url = resolve_stacker_base_url.dup

--- a/lib/betterdoc/containerservice/helpers/link_helper.rb
+++ b/lib/betterdoc/containerservice/helpers/link_helper.rb
@@ -9,8 +9,13 @@ module Betterdoc
         include ActionView::Helpers::UrlHelper
 
         def link_to_stack(content, stack, url_options = {}, html_options = {}, &block)
-          html_options, url_options, stack, content = url_options, stack, content, block if block_given?
-          stack_url = ["/stack/#{stack}", url_options.to_query.presence].compact.join("?") 
+          if block_given?
+            html_options = url_options
+            url_options = stack
+            stack = content
+            content = block
+          end
+          stack_url = ["/stack/#{stack}", url_options.to_query.presence].compact.join("?")
           html_options[:data] ||= {}
           html_options[:data][:stacker_no_hijack] = "true"
           if block_given?

--- a/lib/betterdoc/containerservice/helpers/link_helper.rb
+++ b/lib/betterdoc/containerservice/helpers/link_helper.rb
@@ -8,18 +8,16 @@ module Betterdoc
         extend ActiveSupport::Concern
         include ActionView::Helpers::UrlHelper
 
-        # link_to_stack("some-stack", {}, data: { foo_bar: "fiz-baz" }) do ...
-        # link_to_stack(content -> stack, stack -> url_options, url_options -> html_options) do content
-
-        # link_to_stack("Go to some stack", "some-stack", {}, data: { foo_bar: "fiz-baz" })
-        # link_to_stack(content, stack, url_options, html_options)
-
         def link_to_stack(content, stack, url_options = {}, html_options = {}, &block)
           html_options, url_options, stack, content = url_options, stack, content, block if block_given?
           stack_url = ["/stack/#{stack}", url_options.to_query.presence].compact.join("?") 
           html_options[:data] ||= {}
           html_options[:data][:stacker_no_hijack] = "true"
-          link_to(content, stack_url, html_options)
+          if block_given?
+            link_to(stack_url, html_options, &block)
+          else
+            link_to(content, stack_url, html_options)
+          end
         end
 
         def stacker_link_url(target_path, parameters = {})

--- a/test/betterdoc/containerservice/helpers/link_helper_test.rb
+++ b/test/betterdoc/containerservice/helpers/link_helper_test.rb
@@ -183,9 +183,9 @@ class LinkHelperTest < ActionView::TestCase
 
   test "link_to_stack can handle block with html" do
     assert_dom_equal(
-      '<a data-stacker-no-hijack="true" data-foo-bar="fiz-baz" href="/stack/some-stack"><div class="fancy-mdc">icon</div>"Go to some stack</a>',
+      '<a data-stacker-no-hijack="true" data-foo-bar="fiz-baz" href="/stack/some-stack"><div class="fancy-mdc">icon</div>Go to some stack</a>',
       link_to_stack("some-stack", {}, data: { foo_bar: "fiz-baz" }) do
-        content_tag(:div, "icon", class: "fany-mdc") + 
+        content_tag(:div, "icon", class: "fancy-mdc") + 
         "Go to some stack"
       end
     )

--- a/test/betterdoc/containerservice/helpers/link_helper_test.rb
+++ b/test/betterdoc/containerservice/helpers/link_helper_test.rb
@@ -185,7 +185,7 @@ class LinkHelperTest < ActionView::TestCase
     assert_dom_equal(
       '<a data-stacker-no-hijack="true" data-foo-bar="fiz-baz" href="/stack/some-stack"><div class="fancy-mdc">icon</div>Go to some stack</a>',
       link_to_stack("some-stack", {}, data: { foo_bar: "fiz-baz" }) do
-        content_tag(:div, "icon", class: "fancy-mdc") + 
+        content_tag(:div, "icon", class: "fancy-mdc") +
         "Go to some stack"
       end
     )

--- a/test/betterdoc/containerservice/helpers/link_helper_test.rb
+++ b/test/betterdoc/containerservice/helpers/link_helper_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
+require 'action_view'
 require 'betterdoc/containerservice/helpers/link_helper'
 
-class LinkHelperTest < ActiveSupport::TestCase
+class LinkHelperTest < ActionView::TestCase
 
   test "stacker link url with root url as header" do
 
@@ -147,6 +148,48 @@ class LinkHelperTest < ActiveSupport::TestCase
 
     assert_equal 'http://stacker.example.com/stacks/abc?x=y&aKey=aValue&bKey=bValue', concern.stacker_link_url('stacks/abc?x=y', 'aKey' => 'aValue', 'bKey' => 'bValue')
 
+  end
+
+  test "link_to_stack generates link to stack on stacker" do
+    mocked_request = Object.new
+    mocked_request.stubs('headers').returns('HTTP_X_STACKER_ROOT_URL' => 'http://stacker.example.com')
+
+    concern = Object.new
+    concern.stubs(:request).returns(mocked_request)
+    concern.extend(Betterdoc::Containerservice::Helpers::LinkHelper)
+
+    assert_equal(
+      '<a data-stacker-no-hijack="true" href="/stack/some-stack">Go to some stack</a>',
+      concern.link_to_stack("Go to some stack", "some-stack")
+    )
+  end
+
+  test "link_to_stack generates link with params if they are provided" do
+    mocked_request = Object.new
+    mocked_request.stubs('headers').returns('HTTP_X_STACKER_ROOT_URL' => 'http://stacker.example.com')
+
+    concern = Object.new
+    concern.stubs(:request).returns(mocked_request)
+    concern.extend(Betterdoc::Containerservice::Helpers::LinkHelper)
+
+    assert_equal(
+      '<a data-stacker-no-hijack="true" href="/stack/some-stack?fiz=baz&foo=bar">Go to some stack</a>',
+      concern.link_to_stack("Go to some stack", "some-stack", foo: :bar, fiz: "baz")
+    )
+  end
+
+  test "link_to_stack generates link without loosing data attributes" do
+    mocked_request = Object.new
+    mocked_request.stubs('headers').returns('HTTP_X_STACKER_ROOT_URL' => 'http://stacker.example.com')
+
+    concern = Object.new
+    concern.stubs(:request).returns(mocked_request)
+    concern.extend(Betterdoc::Containerservice::Helpers::LinkHelper)
+
+    assert_equal(
+      '<a data-stacker-no-hijack="true" data-foo-bar="fiz-baz" href="/stack/some-stack">Go to some stack</a>',
+      concern.link_to_stack("Go to some stack", "some-stack", {}, data: { foo_bar: "fiz-baz" })
+    )
   end
 
 end

--- a/test/betterdoc/containerservice/helpers/link_helper_test.rb
+++ b/test/betterdoc/containerservice/helpers/link_helper_test.rb
@@ -3,6 +3,7 @@ require 'action_view'
 require 'betterdoc/containerservice/helpers/link_helper'
 
 class LinkHelperTest < ActionView::TestCase
+  include Betterdoc::Containerservice::Helpers::LinkHelper
 
   test "stacker link url with root url as header" do
 
@@ -151,44 +152,42 @@ class LinkHelperTest < ActionView::TestCase
   end
 
   test "link_to_stack generates link to stack on stacker" do
-    mocked_request = Object.new
-    mocked_request.stubs('headers').returns('HTTP_X_STACKER_ROOT_URL' => 'http://stacker.example.com')
-
-    concern = Object.new
-    concern.stubs(:request).returns(mocked_request)
-    concern.extend(Betterdoc::Containerservice::Helpers::LinkHelper)
-
-    assert_equal(
+    assert_dom_equal(
       '<a data-stacker-no-hijack="true" href="/stack/some-stack">Go to some stack</a>',
-      concern.link_to_stack("Go to some stack", "some-stack")
+      link_to_stack("Go to some stack", "some-stack")
     )
   end
 
   test "link_to_stack generates link with params if they are provided" do
-    mocked_request = Object.new
-    mocked_request.stubs('headers').returns('HTTP_X_STACKER_ROOT_URL' => 'http://stacker.example.com')
-
-    concern = Object.new
-    concern.stubs(:request).returns(mocked_request)
-    concern.extend(Betterdoc::Containerservice::Helpers::LinkHelper)
-
-    assert_equal(
+    assert_dom_equal(
       '<a data-stacker-no-hijack="true" href="/stack/some-stack?fiz=baz&foo=bar">Go to some stack</a>',
-      concern.link_to_stack("Go to some stack", "some-stack", foo: :bar, fiz: "baz")
+      link_to_stack("Go to some stack", "some-stack", foo: :bar, fiz: "baz")
     )
   end
 
   test "link_to_stack generates link without loosing data attributes" do
-    mocked_request = Object.new
-    mocked_request.stubs('headers').returns('HTTP_X_STACKER_ROOT_URL' => 'http://stacker.example.com')
-
-    concern = Object.new
-    concern.stubs(:request).returns(mocked_request)
-    concern.extend(Betterdoc::Containerservice::Helpers::LinkHelper)
-
-    assert_equal(
+    assert_dom_equal(
       '<a data-stacker-no-hijack="true" data-foo-bar="fiz-baz" href="/stack/some-stack">Go to some stack</a>',
-      concern.link_to_stack("Go to some stack", "some-stack", {}, data: { foo_bar: "fiz-baz" })
+      link_to_stack("Go to some stack", "some-stack", {}, data: { foo_bar: "fiz-baz" })
+    )
+  end
+
+  test "link_to_stack can handle block" do
+    assert_dom_equal(
+      '<a data-stacker-no-hijack="true" data-foo-bar="fiz-baz" href="/stack/some-stack">Go to some stack</a>',
+      link_to_stack("some-stack", {}, data: { foo_bar: "fiz-baz" }) do
+        "Go to some stack"
+      end
+    )
+  end
+
+  test "link_to_stack can handle block with html" do
+    assert_dom_equal(
+      '<a data-stacker-no-hijack="true" data-foo-bar="fiz-baz" href="/stack/some-stack"><div class="fancy-mdc">icon</div>"Go to some stack</a>',
+      link_to_stack("some-stack", {}, data: { foo_bar: "fiz-baz" }) do
+        content_tag(:div, "icon", class: "fany-mdc") + 
+        "Go to some stack"
+      end
     )
   end
 


### PR DESCRIPTION
This will implement the method `link_to_stack` as described [here](https://trello.com/c/s2T06oe4/170-add-link-to-stack-helper-to-container-service-gem)